### PR TITLE
Support for error paths

### DIFF
--- a/Factory/JsFormValidatorFactory.php
+++ b/Factory/JsFormValidatorFactory.php
@@ -11,6 +11,8 @@ use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\ResolvedFormTypeInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
@@ -65,7 +67,7 @@ class JsFormValidatorFactory
     /**
      * @param ValidatorInterface    $validator
      * @param TranslatorInterface   $translator
-     * @param \Symfony\Component\Routing\Generator\UrlGeneratorInterface $router
+     * @param UrlGeneratorInterface $router
      * @param array                 $config
      * @param string                $domain
      */
@@ -244,7 +246,7 @@ class JsFormValidatorFactory
         $model                 = new JsFormElement;
         $model->id             = $this->getElementId($form);
         $model->name           = $form->getName();
-        $model->type           = get_class($conf->getType()->getInnerType());
+        $model->type           = $this->getFormTypeHierarchy($conf->getType());
         $model->invalidMessage = $this->translateMessage(
             $conf->getOption('invalid_message'),
             $conf->getOption('invalid_message_parameters')
@@ -614,5 +616,16 @@ class JsFormValidatorFactory
         }
 
         return implode("\n", $result);
+    }
+
+    private function getFormTypeHierarchy(ResolvedFormTypeInterface $formType)
+    {
+        $type = array(get_class($formType));
+
+        while ($formType = $formType->getParent()) {
+            $type[] = get_class($formType);
+        }
+
+        return $type;
     }
 }

--- a/Model/JsModelAbstract.php
+++ b/Model/JsModelAbstract.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Fp\JsFormValidatorBundle\Model;
+use Symfony\Component\Validator\Constraint;
 
 /**
  * All the models inherited from this class converted to a similar Javascript model by printing them as a string
@@ -38,6 +39,11 @@ abstract class JsModelAbstract
      */
     public static function phpValueToJs($value)
     {
+        // Initialize "groups" option if it is not set
+        if ($value instanceof Constraint) {
+            $value->groups;
+        }
+
         // For object which has own __toString method
         if ($value instanceof JsModelAbstract) {
             return $value->toJsString();

--- a/Resources/public/js/FpJsFormValidator.js
+++ b/Resources/public/js/FpJsFormValidator.js
@@ -46,6 +46,32 @@ var FpJsDomUtility = {
     }
 };
 
+function FpJsFormError(message) {
+    this.message = message;
+    this.atPath = null;
+
+    this.getTarget = function (rootElement) {
+        if (!this.atPath) {
+            return rootElement;
+        }
+
+        var path = this.atPath.split('.');
+        var targetElement = rootElement;
+        var pathSegment;
+
+        while (pathSegment = path.shift()) {
+            if (!targetElement.children[pathSegment]) {
+                return targetElement;
+            }
+
+            targetElement = targetElement.children[pathSegment];
+        }
+
+        // fallback to rootElement in case the targetElement is not found
+        return targetElement || rootElement;
+    }
+}
+
 function FpJsFormElement() {
     this.id = '';
     this.name = '';
@@ -89,13 +115,36 @@ function FpJsFormElement() {
 
         var self = this;
         var sourceId = 'form-error-' + String(this.id).replace(/_/g, '-');
-        self.errors[sourceId] = FpJsFormValidator.validateElement(self);
+        this.clearErrorsRecursively(sourceId);
 
-        var errorPath = FpJsFormValidator.getErrorPathElement(self);
-        var domNode = self.getDomNode();
-        errorPath.showErrors.apply(domNode, [self.errors[sourceId], sourceId]);
+        if (this.domNode && this.domNode.disabled) {
+            return true;
+        }
 
-        if (self.errors[sourceId].length === 0) {
+        var validationErrors = FpJsFormValidator.validateElement(self);
+        var invalidTargets = {};
+        var validationError, errorTarget;
+
+        for (var v = 0, vel = validationErrors.length; v < vel; ++v) {
+            validationError = validationErrors[v];
+            errorTarget  = validationError.getTarget(self);
+            invalidTargets[errorTarget.id] = errorTarget;
+
+            if (!errorTarget.errors[sourceId]) {
+                errorTarget.errors[sourceId] = [];
+            }
+
+            errorTarget.errors[sourceId].push(validationError.message);
+        }
+
+        for (var id in invalidTargets) {
+            var invalidTarget = invalidTargets[id];
+            var domNode = invalidTarget.getDomNode();
+            var errorPath = FpJsFormValidator.getErrorPathElement(invalidTarget);
+            errorPath.showErrors.apply(domNode, [invalidTarget.errors[sourceId], sourceId]);
+        }
+
+        if (validationErrors.length === 0) {
             return true;
         }
 
@@ -121,6 +170,25 @@ function FpJsFormElement() {
 
         for (var i = 0; i < children.length; i++) {
             children[i].validateRecursively();
+        }
+    };
+
+    this.clearErrors = function (sourceId) {
+        if (!sourceId) {
+            for (sourceId in this.errors) {
+                this.clearErrors(sourceId);
+            }
+        } else {
+            this.errors[sourceId] = [];
+            this.showErrors.apply(this.domNode, [this.errors[sourceId], sourceId]);
+        }
+    };
+
+    this.clearErrorsRecursively = function (sourceId) {
+        this.clearErrors(sourceId);
+
+        for (var childName in this.children) {
+            this.children[childName].clearErrorsRecursively(sourceId);
         }
     };
 
@@ -642,7 +710,7 @@ var FpJsFormValidator = new function () {
             return true;
         } else if (
             element.parent
-            && 'Symfony\\Component\\Form\\Extension\\Core\\Type\\CollectionType' == element.parent.type
+            && this.isElementType(element.parent, 'Symfony\\Component\\Form\\Extension\\Core\\Type\\CollectionType')
         ) {
             var validConstraint = this.getElementValidConstraint(element);
 
@@ -679,6 +747,12 @@ var FpJsFormValidator = new function () {
             }
         }
 
+        for (var e = 0, el = errors.length; e < el; ++e) {
+            if (typeof errors[e] === 'string') {
+                errors[e] = new FpJsFormError(errors[e]);
+            }
+        }
+
         return errors;
     };
 
@@ -711,7 +785,7 @@ var FpJsFormValidator = new function () {
 
         if (i && undefined === value) {
             value = this.getMappedValue(element);
-        } else if ('Symfony\\Component\\Form\\Extension\\Core\\Type\\CollectionType' == element.type) {
+        } else if (this.isElementType(element, 'Symfony\\Component\\Form\\Extension\\Core\\Type\\CollectionType')) {
             value = {};
             for (var childName in element.children) {
                 value[childName] = this.getMappedValue(element.children[childName]);
@@ -760,8 +834,8 @@ var FpJsFormValidator = new function () {
 
         var value;
         if (
-            'Symfony\\Component\\Form\\Extension\\Core\\Type\\CheckboxType' == element.type
-            || 'Symfony\\Component\\Form\\Extension\\Core\\Type\\RadioType' == element.type
+            this.isElementType(element, 'Symfony\\Component\\Form\\Extension\\Core\\Type\\CheckboxType')
+            || this.isElementType(element, 'Symfony\\Component\\Form\\Extension\\Core\\Type\\RadioType')
         ) {
             value = element.domNode.checked;
         } else if ('select' === element.domNode.tagName.toLowerCase()) {
@@ -773,7 +847,7 @@ var FpJsFormValidator = new function () {
                     value.push(field.options[len].value);
                 }
             }
-        } else if ('Symfony\\Component\\Form\\Extension\\Core\\Type\\FileType' == element.type) {
+        } else if (this.isElementType(element, 'Symfony\\Component\\Form\\Extension\\Core\\Type\\FileType')) {
             value = Array.prototype.slice.call(element.domNode.files);
         } else {
             value = this.getInputValue(element);
@@ -1200,4 +1274,16 @@ var FpJsFormValidator = new function () {
 
         return length;
     };
+
+    /**
+     * Checks if the given form element is of the given type
+     *
+     * @param {FpJsFormElement} element
+     * @param {String} type
+     *
+     * @returns {boolean}
+     */
+    this.isElementType = function (element, type) {
+        return element.type.indexOf(type) >= 0;
+    }
 }();

--- a/Resources/public/js/FpJsFormValidator.js
+++ b/Resources/public/js/FpJsFormValidator.js
@@ -46,9 +46,9 @@ var FpJsDomUtility = {
     }
 };
 
-function FpJsFormError(message) {
+function FpJsFormError(message, atPath) {
     this.message = message;
-    this.atPath = null;
+    this.atPath = atPath;
 
     this.getTarget = function (rootElement) {
         if (!this.atPath) {
@@ -92,6 +92,22 @@ function FpJsFormElement() {
         return ['Default'];
     };
 
+    this.get = function (stringPath) {
+        var path = stringPath.split('.');
+        var targetElement = this;
+        var pathSegment;
+
+        while (pathSegment = path.shift()) {
+            if (!targetElement.children[pathSegment]) {
+                throw new Error('Invalid form element path "' + stringPath + '"');
+            }
+
+            targetElement = targetElement.children[pathSegment];
+        }
+
+        return targetElement;
+    };
+
     this.getDomNode = function () {
         var errorPath = FpJsFormValidator.getErrorPathElement(this);
         var domNode = errorPath.domNode;
@@ -106,6 +122,10 @@ function FpJsFormElement() {
         }
 
         return domNode;
+    };
+
+    this.getValue = function () {
+        return FpJsFormValidator.getElementValue(this);
     };
 
     this.validate = function () {
@@ -667,7 +687,7 @@ var FpJsFormValidator = new function () {
      */
     this.validateElement = function (element) {
         var errors = [];
-        var value = this.getElementValue(element);
+        var value = element.getValue();
 
         for (var type in element.data) {
             if ('entity' == type && element.parent && !this.shouldValidEmbedded(element)) {
@@ -1225,7 +1245,7 @@ var FpJsFormValidator = new function () {
      *
      * @returns boolean
      */
-    this.isValueEmty = function (value) {
+    this.isValueEmpty = function (value) {
         return [undefined, null, false].indexOf(value) >= 0 || 0 === this.getValueLength(value);
     };
 

--- a/Resources/public/js/constraints/Blank.js
+++ b/Resources/public/js/constraints/Blank.js
@@ -11,7 +11,7 @@ function SymfonyComponentValidatorConstraintsBlank() {
         var errors = [];
         var f = FpJsFormValidator;
 
-        if (!f.isValueEmty(value)) {
+        if (!f.isValueEmpty(value)) {
             errors.push(this.message.replace('{{ value }}', FpJsBaseConstraint.formatValue(value)));
         }
 

--- a/Resources/public/js/constraints/Date.js
+++ b/Resources/public/js/constraints/Date.js
@@ -12,7 +12,7 @@ function SymfonyComponentValidatorConstraintsDate() {
         var errors = [];
         var f = FpJsFormValidator;
 
-        if (!f.isValueEmty(value) && !regexp.test(value)) {
+        if (!f.isValueEmpty(value) && !regexp.test(value)) {
             errors.push(this.message.replace('{{ value }}', FpJsBaseConstraint.formatValue(value)));
         }
 

--- a/Resources/public/js/constraints/DateTime.js
+++ b/Resources/public/js/constraints/DateTime.js
@@ -12,7 +12,7 @@ function SymfonyComponentValidatorConstraintsDateTime() {
         var errors = [];
         var f = FpJsFormValidator;
 
-        if (!f.isValueEmty(value) && !regexp.test(value)) {
+        if (!f.isValueEmpty(value) && !regexp.test(value)) {
             errors.push(this.message.replace('{{ value }}', FpJsBaseConstraint.formatValue(value)));
         }
 

--- a/Resources/public/js/constraints/Email.js
+++ b/Resources/public/js/constraints/Email.js
@@ -12,7 +12,7 @@ function SymfonyComponentValidatorConstraintsEmail() {
         var errors = [];
         var f = FpJsFormValidator;
 
-        if (!f.isValueEmty(value) && !regexp.test(value)) {
+        if (!f.isValueEmpty(value) && !regexp.test(value)) {
             errors.push(this.message.replace('{{ value }}', FpJsBaseConstraint.formatValue(value)));
         }
 

--- a/Resources/public/js/constraints/EqualTo.js
+++ b/Resources/public/js/constraints/EqualTo.js
@@ -12,7 +12,7 @@ function SymfonyComponentValidatorConstraintsEqualTo() {
         var errors = [];
         var f = FpJsFormValidator;
 
-        if (!f.isValueEmty(value) && this.value != value) {
+        if (!f.isValueEmpty(value) && this.value != value) {
             errors.push(
                 this.message
                     .replace('{{ value }}', FpJsBaseConstraint.formatValue(value))

--- a/Resources/public/js/constraints/GreaterThan.js
+++ b/Resources/public/js/constraints/GreaterThan.js
@@ -10,7 +10,7 @@ function SymfonyComponentValidatorConstraintsGreaterThan() {
 
     this.validate = function (value) {
         var f = FpJsFormValidator;
-        if (f.isValueEmty(value) || value > this.value) {
+        if (f.isValueEmpty(value) || value > this.value) {
             return [];
         } else {
             return [

--- a/Resources/public/js/constraints/GreaterThanOrEqual.js
+++ b/Resources/public/js/constraints/GreaterThanOrEqual.js
@@ -10,7 +10,7 @@ function SymfonyComponentValidatorConstraintsGreaterThanOrEqual() {
 
     this.validate = function (value) {
         var f = FpJsFormValidator;
-        if (f.isValueEmty(value) || value >= this.value) {
+        if (f.isValueEmpty(value) || value >= this.value) {
             return [];
         } else {
             return [

--- a/Resources/public/js/constraints/Ip.js
+++ b/Resources/public/js/constraints/Ip.js
@@ -12,7 +12,7 @@ function SymfonyComponentValidatorConstraintsIp() {
         var errors = [];
         var f = FpJsFormValidator;
 
-        if (!f.isValueEmty(value) && !regexp.test(value)) {
+        if (!f.isValueEmpty(value) && !regexp.test(value)) {
             errors.push(this.message.replace('{{ value }}', FpJsBaseConstraint.formatValue(value)));
         }
 

--- a/Resources/public/js/constraints/LessThan.js
+++ b/Resources/public/js/constraints/LessThan.js
@@ -10,7 +10,7 @@ function SymfonyComponentValidatorConstraintsLessThan() {
 
     this.validate = function (value) {
         var f = FpJsFormValidator;
-        if (f.isValueEmty(value) || value < this.value) {
+        if (f.isValueEmpty(value) || value < this.value) {
             return [];
         } else {
             return [

--- a/Resources/public/js/constraints/LessThanOrEqual.js
+++ b/Resources/public/js/constraints/LessThanOrEqual.js
@@ -10,7 +10,7 @@ function SymfonyComponentValidatorConstraintsLessThanOrEqual() {
 
     this.validate = function (value) {
         var f = FpJsFormValidator;
-        if (f.isValueEmty(value) || value <= this.value) {
+        if (f.isValueEmpty(value) || value <= this.value) {
             return [];
         } else {
             return [

--- a/Resources/public/js/constraints/NotBlank.js
+++ b/Resources/public/js/constraints/NotBlank.js
@@ -11,7 +11,7 @@ function SymfonyComponentValidatorConstraintsNotBlank() {
         var errors = [];
         var f = FpJsFormValidator;
 
-        if (f.isValueEmty(value)) {
+        if (f.isValueEmpty(value)) {
             errors.push(this.message.replace('{{ value }}', FpJsBaseConstraint.formatValue(value)));
         }
 

--- a/Resources/public/js/constraints/Range.js
+++ b/Resources/public/js/constraints/Range.js
@@ -15,7 +15,7 @@ function SymfonyComponentValidatorConstraintsRange() {
         var errors = [];
         var f = FpJsFormValidator;
 
-        if (f.isValueEmty(value)) {
+        if (f.isValueEmpty(value)) {
             return errors;
         }
         if (isNaN(value)) {

--- a/Resources/public/js/constraints/Regex.js
+++ b/Resources/public/js/constraints/Regex.js
@@ -13,7 +13,7 @@ function SymfonyComponentValidatorConstraintsRegex() {
         var errors = [];
         var f = FpJsFormValidator;
 
-        if (!f.isValueEmty(value) && !this.pattern.test(value)) {
+        if (!f.isValueEmpty(value) && !this.pattern.test(value)) {
             errors.push(this.message.replace('{{ value }}', FpJsBaseConstraint.formatValue(value)));
         }
 

--- a/Resources/public/js/constraints/Time.js
+++ b/Resources/public/js/constraints/Time.js
@@ -12,7 +12,7 @@ function SymfonyComponentValidatorConstraintsTime() {
         var errors = [];
         var f = FpJsFormValidator;
 
-        if (!f.isValueEmty(value) && !regexp.test(value)) {
+        if (!f.isValueEmpty(value) && !regexp.test(value)) {
             errors.push(this.message.replace('{{ value }}', FpJsBaseConstraint.formatValue(value)));
         }
 

--- a/Resources/public/js/constraints/Url.js
+++ b/Resources/public/js/constraints/Url.js
@@ -12,7 +12,7 @@ function SymfonyComponentValidatorConstraintsUrl() {
         var errors = [];
         var f = FpJsFormValidator;
 
-        if (!f.isValueEmty(value) && !regexp.test(value)) {
+        if (!f.isValueEmpty(value) && !regexp.test(value)) {
             element.domNode.value = 'http://' + value;
             errors.push(this.message.replace('{{ value }}', FpJsBaseConstraint.formatValue('http://' + value)));
         }

--- a/Resources/public/js/fp_js_validator.js
+++ b/Resources/public/js/fp_js_validator.js
@@ -46,6 +46,32 @@ var FpJsDomUtility = {
     }
 };
 
+function FpJsFormError(message) {
+    this.message = message;
+    this.atPath = null;
+
+    this.getTarget = function (rootElement) {
+        if (!this.atPath) {
+            return rootElement;
+        }
+
+        var path = this.atPath.split('.');
+        var targetElement = rootElement;
+        var pathSegment;
+
+        while (pathSegment = path.shift()) {
+            if (!targetElement.children[pathSegment]) {
+                return targetElement;
+            }
+
+            targetElement = targetElement.children[pathSegment];
+        }
+
+        // fallback to rootElement in case the targetElement is not found
+        return targetElement || rootElement;
+    }
+}
+
 function FpJsFormElement() {
     this.id = '';
     this.name = '';
@@ -89,13 +115,36 @@ function FpJsFormElement() {
 
         var self = this;
         var sourceId = 'form-error-' + String(this.id).replace(/_/g, '-');
-        self.errors[sourceId] = FpJsFormValidator.validateElement(self);
+        this.clearErrorsRecursively(sourceId);
 
-        var errorPath = FpJsFormValidator.getErrorPathElement(self);
-        var domNode = self.getDomNode();
-        errorPath.showErrors.apply(domNode, [self.errors[sourceId], sourceId]);
+        if (this.domNode && this.domNode.disabled) {
+            return true;
+        }
 
-        if (self.errors[sourceId].length === 0) {
+        var validationErrors = FpJsFormValidator.validateElement(self);
+        var invalidTargets = {};
+        var validationError, errorTarget;
+
+        for (var v = 0, vel = validationErrors.length; v < vel; ++v) {
+            validationError = validationErrors[v];
+            errorTarget  = validationError.getTarget(self);
+            invalidTargets[errorTarget.id] = errorTarget;
+
+            if (!errorTarget.errors[sourceId]) {
+                errorTarget.errors[sourceId] = [];
+            }
+
+            errorTarget.errors[sourceId].push(validationError.message);
+        }
+
+        for (var id in invalidTargets) {
+            var invalidTarget = invalidTargets[id];
+            var domNode = invalidTarget.getDomNode();
+            var errorPath = FpJsFormValidator.getErrorPathElement(invalidTarget);
+            errorPath.showErrors.apply(domNode, [invalidTarget.errors[sourceId], sourceId]);
+        }
+
+        if (validationErrors.length === 0) {
             return true;
         }
 
@@ -121,6 +170,25 @@ function FpJsFormElement() {
 
         for (var i = 0; i < children.length; i++) {
             children[i].validateRecursively();
+        }
+    };
+
+    this.clearErrors = function (sourceId) {
+        if (!sourceId) {
+            for (sourceId in this.errors) {
+                this.clearErrors(sourceId);
+            }
+        } else {
+            this.errors[sourceId] = [];
+            this.showErrors.apply(this.domNode, [this.errors[sourceId], sourceId]);
+        }
+    };
+
+    this.clearErrorsRecursively = function (sourceId) {
+        this.clearErrors(sourceId);
+
+        for (var childName in this.children) {
+            this.children[childName].clearErrorsRecursively(sourceId);
         }
     };
 
@@ -642,7 +710,7 @@ var FpJsFormValidator = new function () {
             return true;
         } else if (
             element.parent
-            && 'Symfony\\Component\\Form\\Extension\\Core\\Type\\CollectionType' == element.parent.type
+            && this.isElementType(element.parent, 'Symfony\\Component\\Form\\Extension\\Core\\Type\\CollectionType')
         ) {
             var validConstraint = this.getElementValidConstraint(element);
 
@@ -679,6 +747,12 @@ var FpJsFormValidator = new function () {
             }
         }
 
+        for (var e = 0, el = errors.length; e < el; ++e) {
+            if (typeof errors[e] === 'string') {
+                errors[e] = new FpJsFormError(errors[e]);
+            }
+        }
+
         return errors;
     };
 
@@ -711,7 +785,7 @@ var FpJsFormValidator = new function () {
 
         if (i && undefined === value) {
             value = this.getMappedValue(element);
-        } else if ('Symfony\\Component\\Form\\Extension\\Core\\Type\\CollectionType' == element.type) {
+        } else if (this.isElementType(element, 'Symfony\\Component\\Form\\Extension\\Core\\Type\\CollectionType')) {
             value = {};
             for (var childName in element.children) {
                 value[childName] = this.getMappedValue(element.children[childName]);
@@ -760,8 +834,8 @@ var FpJsFormValidator = new function () {
 
         var value;
         if (
-            'Symfony\\Component\\Form\\Extension\\Core\\Type\\CheckboxType' == element.type
-            || 'Symfony\\Component\\Form\\Extension\\Core\\Type\\RadioType' == element.type
+            this.isElementType(element, 'Symfony\\Component\\Form\\Extension\\Core\\Type\\CheckboxType')
+            || this.isElementType(element, 'Symfony\\Component\\Form\\Extension\\Core\\Type\\RadioType')
         ) {
             value = element.domNode.checked;
         } else if ('select' === element.domNode.tagName.toLowerCase()) {
@@ -773,7 +847,7 @@ var FpJsFormValidator = new function () {
                     value.push(field.options[len].value);
                 }
             }
-        } else if ('Symfony\\Component\\Form\\Extension\\Core\\Type\\FileType' == element.type) {
+        } else if (this.isElementType(element, 'Symfony\\Component\\Form\\Extension\\Core\\Type\\FileType')) {
             value = Array.prototype.slice.call(element.domNode.files);
         } else {
             value = this.getInputValue(element);
@@ -1200,6 +1274,18 @@ var FpJsFormValidator = new function () {
 
         return length;
     };
+
+    /**
+     * Checks if the given form element is of the given type
+     *
+     * @param {FpJsFormElement} element
+     * @param {String} type
+     *
+     * @returns {boolean}
+     */
+    this.isElementType = function (element, type) {
+        return element.type.indexOf(type) >= 0;
+    }
 }();
 
 //noinspection JSUnusedGlobalSymbols,JSUnusedGlobalSymbols

--- a/Resources/public/js/fp_js_validator.js
+++ b/Resources/public/js/fp_js_validator.js
@@ -46,9 +46,9 @@ var FpJsDomUtility = {
     }
 };
 
-function FpJsFormError(message) {
+function FpJsFormError(message, atPath) {
     this.message = message;
-    this.atPath = null;
+    this.atPath = atPath;
 
     this.getTarget = function (rootElement) {
         if (!this.atPath) {
@@ -106,6 +106,26 @@ function FpJsFormElement() {
         }
 
         return domNode;
+    };
+
+    this.get = function (stringPath) {
+        var path = stringPath.split('.');
+        var targetElement = this;
+        var pathSegment;
+
+        while (pathSegment = path.shift()) {
+            if (!targetElement.children[pathSegment]) {
+                throw new Error('Invalid form element path "' + stringPath + '"');
+            }
+
+            targetElement = targetElement.children[pathSegment];
+        }
+
+        return targetElement;
+    };
+
+    this.getValue = function () {
+        return FpJsFormValidator.getElementValue(this);
     };
 
     this.validate = function () {
@@ -667,7 +687,7 @@ var FpJsFormValidator = new function () {
      */
     this.validateElement = function (element) {
         var errors = [];
-        var value = this.getElementValue(element);
+        var value = element.getValue();
 
         for (var type in element.data) {
             if ('entity' == type && element.parent && !this.shouldValidEmbedded(element)) {
@@ -1225,7 +1245,7 @@ var FpJsFormValidator = new function () {
      *
      * @returns boolean
      */
-    this.isValueEmty = function (value) {
+    this.isValueEmpty = function (value) {
         return [undefined, null, false].indexOf(value) >= 0 || 0 === this.getValueLength(value);
     };
 
@@ -1301,7 +1321,7 @@ function SymfonyComponentValidatorConstraintsBlank() {
         var errors = [];
         var f = FpJsFormValidator;
 
-        if (!f.isValueEmty(value)) {
+        if (!f.isValueEmpty(value)) {
             errors.push(this.message.replace('{{ value }}', FpJsBaseConstraint.formatValue(value)));
         }
 
@@ -1536,7 +1556,7 @@ function SymfonyComponentValidatorConstraintsDate() {
         var errors = [];
         var f = FpJsFormValidator;
 
-        if (!f.isValueEmty(value) && !regexp.test(value)) {
+        if (!f.isValueEmpty(value) && !regexp.test(value)) {
             errors.push(this.message.replace('{{ value }}', FpJsBaseConstraint.formatValue(value)));
         }
 
@@ -1558,7 +1578,7 @@ function SymfonyComponentValidatorConstraintsDateTime() {
         var errors = [];
         var f = FpJsFormValidator;
 
-        if (!f.isValueEmty(value) && !regexp.test(value)) {
+        if (!f.isValueEmpty(value) && !regexp.test(value)) {
             errors.push(this.message.replace('{{ value }}', FpJsBaseConstraint.formatValue(value)));
         }
 
@@ -1579,7 +1599,7 @@ function SymfonyComponentValidatorConstraintsEmail() {
         var errors = [];
         var f = FpJsFormValidator;
 
-        if (!f.isValueEmty(value) && !regexp.test(value)) {
+        if (!f.isValueEmpty(value) && !regexp.test(value)) {
             errors.push(this.message.replace('{{ value }}', FpJsBaseConstraint.formatValue(value)));
         }
 
@@ -1601,7 +1621,7 @@ function SymfonyComponentValidatorConstraintsEqualTo() {
         var errors = [];
         var f = FpJsFormValidator;
 
-        if (!f.isValueEmty(value) && this.value != value) {
+        if (!f.isValueEmpty(value) && this.value != value) {
             errors.push(
                 this.message
                     .replace('{{ value }}', FpJsBaseConstraint.formatValue(value))
@@ -1634,7 +1654,7 @@ function SymfonyComponentValidatorConstraintsGreaterThan() {
 
     this.validate = function (value) {
         var f = FpJsFormValidator;
-        if (f.isValueEmty(value) || value > this.value) {
+        if (f.isValueEmpty(value) || value > this.value) {
             return [];
         } else {
             return [
@@ -1658,7 +1678,7 @@ function SymfonyComponentValidatorConstraintsGreaterThanOrEqual() {
 
     this.validate = function (value) {
         var f = FpJsFormValidator;
-        if (f.isValueEmty(value) || value >= this.value) {
+        if (f.isValueEmpty(value) || value >= this.value) {
             return [];
         } else {
             return [
@@ -1709,7 +1729,7 @@ function SymfonyComponentValidatorConstraintsIp() {
         var errors = [];
         var f = FpJsFormValidator;
 
-        if (!f.isValueEmty(value) && !regexp.test(value)) {
+        if (!f.isValueEmpty(value) && !regexp.test(value)) {
             errors.push(this.message.replace('{{ value }}', FpJsBaseConstraint.formatValue(value)));
         }
 
@@ -1847,7 +1867,7 @@ function SymfonyComponentValidatorConstraintsLessThan() {
 
     this.validate = function (value) {
         var f = FpJsFormValidator;
-        if (f.isValueEmty(value) || value < this.value) {
+        if (f.isValueEmpty(value) || value < this.value) {
             return [];
         } else {
             return [
@@ -1871,7 +1891,7 @@ function SymfonyComponentValidatorConstraintsLessThanOrEqual() {
 
     this.validate = function (value) {
         var f = FpJsFormValidator;
-        if (f.isValueEmty(value) || value <= this.value) {
+        if (f.isValueEmpty(value) || value <= this.value) {
             return [];
         } else {
             return [
@@ -1896,7 +1916,7 @@ function SymfonyComponentValidatorConstraintsNotBlank() {
         var errors = [];
         var f = FpJsFormValidator;
 
-        if (f.isValueEmty(value)) {
+        if (f.isValueEmpty(value)) {
             errors.push(this.message.replace('{{ value }}', FpJsBaseConstraint.formatValue(value)));
         }
 
@@ -1998,7 +2018,7 @@ function SymfonyComponentValidatorConstraintsRange() {
         var errors = [];
         var f = FpJsFormValidator;
 
-        if (f.isValueEmty(value)) {
+        if (f.isValueEmpty(value)) {
             return errors;
         }
         if (isNaN(value)) {
@@ -2046,7 +2066,7 @@ function SymfonyComponentValidatorConstraintsRegex() {
         var errors = [];
         var f = FpJsFormValidator;
 
-        if (!f.isValueEmty(value) && !this.pattern.test(value)) {
+        if (!f.isValueEmpty(value) && !this.pattern.test(value)) {
             errors.push(this.message.replace('{{ value }}', FpJsBaseConstraint.formatValue(value)));
         }
 
@@ -2073,7 +2093,7 @@ function SymfonyComponentValidatorConstraintsTime() {
         var errors = [];
         var f = FpJsFormValidator;
 
-        if (!f.isValueEmty(value) && !regexp.test(value)) {
+        if (!f.isValueEmpty(value) && !regexp.test(value)) {
             errors.push(this.message.replace('{{ value }}', FpJsBaseConstraint.formatValue(value)));
         }
 
@@ -2293,7 +2313,7 @@ function SymfonyComponentValidatorConstraintsUrl() {
         var errors = [];
         var f = FpJsFormValidator;
 
-        if (!f.isValueEmty(value) && !regexp.test(value)) {
+        if (!f.isValueEmpty(value) && !regexp.test(value)) {
             element.domNode.value = 'http://' + value;
             errors.push(this.message.replace('{{ value }}', FpJsBaseConstraint.formatValue('http://' + value)));
         }


### PR DESCRIPTION
- Manually merged in https://github.com/usetreno/JsFormValidatorBundle/tree/error-path
- FpJsFormElement.get()
- FpJsFormElement.getValue()
- FpJsFormError constructor accepts path
- isValueEmpy -> isValueEmpty
